### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,41 @@ CineScripter harnesses bespoke solutions for content generation:
 * <a href="https://www.unsplash.com/">Unsplash for relevant media</a>
 * <a href="https://developers.giphy.com/">Giphy for engaging media</a>
 * <a href="https://beta.elevenlabs.io/">ElevenLabs for TTS</a>
+* <a href="https://docs.60db.ai/">60db for TTS</a>
 * <a href="https://weaviate.io" >Weaviate for Vector storage needs</a>
 
-Please ensure having **API keys** for Giphy, ElevenLabs, OpenAI, and Weaviate. For more details on which API keys are needed, please check the `./config/.env.dist` file.
+Please ensure having **API keys** for Giphy, OpenAI, Weaviate, and a TTS provider (ElevenLabs and/or 60db). For more details on which API keys are needed, please check the `./config/.env.dist` file.
+
+## Text-To-Speech providers
+
+CineScripter narrates each sentence of the generated script using a pluggable
+Text-To-Speech (TTS) provider. Two providers are supported out of the box:
+
+| Provider | Value for `TTS_PROVIDER` | API key | Voice id |
+|----------|--------------------------|---------|----------|
+| ElevenLabs | `elevenlabs` (default) | `ELEVEN_API_KEY` | `VOICE_ID` |
+| 60db | `60db` (alias `sixtydb`) | `SIXTYDB_API_KEY` | `SIXTYDB_VOICE_ID` |
+
+The active provider is selected at runtime via the `TTS_PROVIDER` environment
+variable. No code changes are required to switch — just update your `.env`:
+
+```bash
+# Use ElevenLabs (default behaviour)
+TTS_PROVIDER=elevenlabs
+ELEVEN_API_KEY=your_elevenlabs_key
+VOICE_ID=your_elevenlabs_voice_id
+
+# Use 60db
+TTS_PROVIDER=60db
+SIXTYDB_API_KEY=sk_live_your_60db_key
+SIXTYDB_VOICE_ID=your_60db_voice_id
+```
+
+60db uses the REST batch endpoint (`POST https://api.60db.ai/tts-synthesize`)
+and authenticates with a `Bearer` token. You can tune the synthesis
+(`output_format`, `speed`, `stability`, `similarity`, `enhance`) in the
+`SIXTYDB` settings block in `src/utils/settings.py`. To discover the available
+`voice_id` values for your account, call `GET https://api.60db.ai/myvoices`
+(also exposed via `SixtyDB().list_voices()`).
 
 

--- a/config/.env.dist
+++ b/config/.env.dist
@@ -1,4 +1,7 @@
+TTS_PROVIDER=elevenlabs
 VOICE_ID=voice_id
+SIXTYDB_API_KEY=sixtydb_api_key
+SIXTYDB_VOICE_ID=sixtydb_voice_id
 GIPHY_API_KEY=giphy_api_key
 OPENAI_API_KEY=openai_api_key
 WEAVIATE_HOST=weaviate_host

--- a/src/generation/audio.py
+++ b/src/generation/audio.py
@@ -2,12 +2,15 @@ import os
 
 from elevenlabs import generate, save
 
+from generation.sixtydb import SixtyDB
 from utils.common import SettingsLoader
 from utils.logs import logger
 
 FOLDER_PREFIX = "audio/"
 
-class Audio:
+
+class ElevenLabsAudio:
+    """ElevenLabs Text-To-Speech provider."""
 
     APP_NAME = "ELEVENLABS"
 
@@ -31,3 +34,39 @@ class Audio:
         logger.info('Downloaded %s', file_path)
         section["media"]["audio_path"] = file_path
         return section
+
+
+class Audio:
+    """Audio entrypoint that dispatches to the configured TTS provider.
+
+    The active provider is selected via the ``TTS`` settings (``TTS_PROVIDER``
+    environment variable). Every provider exposes the same
+    ``async generate(section, output_folder)`` signature so the rest of the
+    generation pipeline is provider-agnostic.
+    """
+
+    APP_NAME = "TTS"
+
+    PROVIDERS = {
+        "elevenlabs": ElevenLabsAudio,
+        "60db": SixtyDB,
+        "sixtydb": SixtyDB,
+    }
+
+    def __init__(self, **kwargs):
+        self.options = SettingsLoader.load(
+            self.APP_NAME,
+            kwargs
+        )
+        provider = self.options.get("provider")
+        provider_cls = self.PROVIDERS.get(provider)
+        if provider_cls is None:
+            raise ValueError(
+                f"Unknown TTS provider '{provider}'. "
+                f"Available providers: {list(self.PROVIDERS)}"
+            )
+        logger.info("Using TTS provider: %s", provider)
+        self.provider = provider_cls()
+
+    async def generate(self, section: dict, output_folder: str) -> str:
+        return await self.provider.generate(section, output_folder)

--- a/src/generation/sixtydb.py
+++ b/src/generation/sixtydb.py
@@ -1,0 +1,86 @@
+import base64
+import os
+
+import requests
+
+from utils.common import SettingsLoader
+from utils.logs import logger
+
+FOLDER_PREFIX = "audio/"
+MAX_TEXT_LENGTH = 5000
+
+
+class SixtyDB:
+    """60db Text-To-Speech provider.
+
+    Mirrors the interface of the other audio providers: ``generate`` takes a
+    section and an output folder, writes a narration file to disk, records the
+    resulting path in ``section["media"]["audio_path"]`` and returns the section.
+    """
+
+    APP_NAME = "SIXTYDB"
+
+    def __init__(self, **kwargs):
+        self.options = SettingsLoader.load(
+            self.APP_NAME,
+            kwargs
+        )
+
+    async def generate(self, section: dict, output_folder: str) -> str:
+        logger.info('Generating audio for %s', section)
+        os.makedirs(os.path.join(output_folder, FOLDER_PREFIX), exist_ok=True)
+
+        text = section['sentence'][:MAX_TEXT_LENGTH]
+        headers = {
+            "Authorization": f"Bearer {self.options.get('api_key')}",
+        }
+        payload = {
+            "text": text,
+            "voice_id": self.options.get("voice_id"),
+            "speed": self.options.get("speed"),
+            "stability": self.options.get("stability"),
+            "similarity": self.options.get("similarity"),
+            "enhance": self.options.get("enhance"),
+            "output_format": self.options.get("output_format"),
+        }
+
+        response = requests.post(
+            f"{self.options.get('api')}/tts-synthesize",
+            json=payload,
+            headers=headers,
+            timeout=self.options.get("timeout"),
+        )
+        response.raise_for_status()
+
+        parsed_response = response.json()
+        if not parsed_response.get("success"):
+            raise RuntimeError(
+                f"60db TTS failed: {parsed_response.get('message')}"
+            )
+
+        audio = base64.b64decode(parsed_response["audio_base64"])
+        extension = parsed_response.get("output_format") or self.options.get("output_format")
+        file_name = f"{section['index']}-{section['topic_slug']}.{extension}"
+        file_path = os.path.join(output_folder, FOLDER_PREFIX, file_name)
+        with open(file_path, "wb") as fl:
+            fl.write(audio)
+
+        logger.info('Downloaded %s', file_path)
+        section["media"]["audio_path"] = file_path
+        return section
+
+    def list_voices(self) -> list:
+        """Fetch the voices available to the configured API key.
+
+        Helper to discover ``voice_id`` values to put in ``SIXTYDB_VOICE_ID``.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.options.get('api_key')}",
+        }
+        response = requests.get(
+            f"{self.options.get('api')}/myvoices",
+            headers=headers,
+            timeout=self.options.get("timeout"),
+        )
+        response.raise_for_status()
+        return response.json().get("data", [])

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -4,9 +4,27 @@ from string import Template
 
 PROMPTS_PATH = os.getenv("PROMPTS_PATH", "./prompts/")
 
+# Selects which TTS provider the Audio component dispatches to.
+# Supported values: "elevenlabs", "60db" (alias: "sixtydb").
+TTS = {
+    "provider": os.getenv("TTS_PROVIDER", "elevenlabs"),
+}
+
 ELEVENLABS = {
     "voice": os.getenv("VOICE_ID"),
     "model": "eleven_multilingual_v1",
+}
+
+SIXTYDB = {
+    "api_key": os.getenv("SIXTYDB_API_KEY"),
+    "voice_id": os.getenv("SIXTYDB_VOICE_ID"),
+    "api": "https://api.60db.ai",
+    "timeout": 60,
+    "output_format": "wav",  # mp3, wav, ogg, flac
+    "speed": 1,              # 0.5 - 2.0
+    "stability": 50,         # 0 - 100 (expressiveness vs. consistency)
+    "similarity": 75,        # 0 - 100 (voice matching accuracy)
+    "enhance": True,
 }
 
 GIPHY = {


### PR DESCRIPTION
What we added  
  A pluggable TTS provider system — 60db now works alongside ElevenLabs, switchable via one env var:

  - src/generation/sixtydb.py (new) — 60db provider calling POST /tts-synthesize (Bearer auth, base64 → audio file). Includes a       
  list_voices() helper.
  - src/generation/audio.py — Audio is now a dispatcher that picks the provider; old ElevenLabs logic moved to ElevenLabsAudio. Rest
  of the pipeline unchanged.
  - src/utils/settings.py — added TTS (provider switch) and SIXTYDB config dicts.
  - config/.env.dist + README.md — documented the new env vars and usage.

  How to use it

  Set in .env:

  # Use 60db
  TTS_PROVIDER=60db
  SIXTYDB_API_KEY=sk_live_your_key
  SIXTYDB_VOICE_ID=your_voice_id

  # Or keep ElevenLabs (default)
  TTS_PROVIDER=elevenlabs

  Then run normally — no code changes needed:

  python src/main.py --prompt "what is machine learning" --tone informative

  Get a voice id with: curl -H "Authorization: Bearer sk_live_..." https://api.60db.ai/myvoices